### PR TITLE
fixed image timestamp (microseconds -> nanoseconds)

### DIFF
--- a/src/nerian_stereo_node.cpp
+++ b/src/nerian_stereo_node.cpp
@@ -165,7 +165,7 @@ public:
                     stamp = ros::Time::now();
                 } else {
                     int secs = 0, microsecs = 0;
-                    imagePair.getTimestamp(secs, microsecs);
+                    imagePair.getTimestamp(secs, 1000*microsecs);
                     stamp = ros::Time(secs, microsecs);
                 }
 


### PR DESCRIPTION
see:
 * [ros::Time constructor documentation](http://docs.ros.org/latest/api/rostime/html/classros_1_1Time.html#aa726bdbe40e242fdd698922a7e5a607d)
 * [visiontransfer::ImagePair::getTimestamp method documentation](https://nerian.com/support/documentation/api-doc/html/classvisiontransfer_1_1ImagePair.html#adf09651dc3b8d30d12523d34c0bdacb4)